### PR TITLE
Require Rails 6.0 or higher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     cased-rails (0.3.0)
       cased-ruby (~> 0.3.3)
-      rails (~> 6.0.2)
+      rails (>= 6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/cased-rails.gemspec
+++ b/cased-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_dependency 'cased-ruby', '~> 0.3.3'
-  spec.add_dependency 'rails', '~> 6.0.2'
+  spec.add_dependency 'rails', '>= 6.0'
 
   spec.add_development_dependency 'mocha', '1.11.2'
   spec.add_development_dependency 'pg', '1.2.1'


### PR DESCRIPTION
Per https://github.com/cased/cased-rails/issues/1 this PR loosens the restriction on Rails version to anything greater than Rails 6. We can likely even go back to Rails 5, will just need to test first.