### PR TITLE
favicon_link_tag requires file extension

### DIFF
--- a/app/views/layouts/cased/cli.html.erb
+++ b/app/views/layouts/cased/cli.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>Cased</title>
     <%= csp_meta_tag %>
-    <%= favicon_link_tag 'cased/favicon' %>
+    <%= favicon_link_tag 'cased/favicon.ico' %>
     <%= javascript_include_tag 'cased/index' %>
     <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
   </head>


### PR DESCRIPTION
Sprockets will not be able to find favicon unless we specify the `.ico` file extension.