### PR TITLE
Only filter parameters in staging and production

### DIFF
--- a/lib/cased/rails/config.rb
+++ b/lib/cased/rails/config.rb
@@ -28,7 +28,7 @@ module Cased
         @filter_parameters = if ENV['CASED_FILTER_PARAMETERS']
           parse_bool(ENV['CASED_FILTER_PARAMETERS'])
         else
-          true
+          ::Rails.env.staging? || ::Rails.env.production?
         end
       end
     end


### PR DESCRIPTION
This change makes it so only staging and production environments have parameters filtered in `rails console` by default.