### PR TITLE
Bug Fix | Multiple Submissions on Reason Form from Rapid Clicks

### DIFF
--- a/app/assets/javascripts/cased/index.js
+++ b/app/assets/javascripts/cased/index.js
@@ -72,4 +72,15 @@ window.addEventListener("DOMContentLoaded", (event) => {
       casedLoggedOutContainer.classList.remove("hidden");
     });
   }
+
+  const casedReasonFormContainer = document.getElementById("guard-reason-required-form");
+  if (casedReasonFormContainer) {
+    casedReasonFormContainer.addEventListener("submit", (event) => {
+      const submitButton = event.currentTarget.querySelector("button[type='submit']");
+      // Container will change after submission; no need to re-enable the button
+      if (submitButton) {
+        submitButton.disabled = true;
+      }
+    });
+  }
 });


### PR DESCRIPTION
* Add submit listener to guard-reason-required-form to disable the submit button after first click

Steps to reproduce:
1. Navigate to request access with a required reason
2. Enter reason
3. Quickly click the submit button several times
4. Looking at the Cased activity logs, you should see several requests with the ~ same `Requested at` timestamps

### Before Disabling Submit Button
![Large GIF (1406x852)](https://user-images.githubusercontent.com/88391207/178030322-acb7e03a-e5a4-48e7-9750-ad79e84d4ca4.gif)

#### Before Disabling Submit Button: Activity Logs
<img width="230" alt="Screen Shot 2022-07-08 at 12 04 40 PM" src="https://user-images.githubusercontent.com/88391207/178030278-40d775b0-b85e-45f2-aea2-5f2912e0868c.png">

### After Disabling Submit Button
![Large GIF (1406x852)](https://user-images.githubusercontent.com/88391207/178030168-624ca7b1-6796-4ec3-8594-617009f3dad6.gif)

